### PR TITLE
Expose a Builder-based encode interface.

### DIFF
--- a/Data/Csv.hs
+++ b/Data/Csv.hs
@@ -40,6 +40,7 @@ module Data.Csv
     , EncodeOptions(..)
     , defaultEncodeOptions
     , encodeWith
+    , encodeBuilderWith
     , encodeByNameWith
 
     -- * Core CSV types

--- a/Data/Csv/Encoding.hs
+++ b/Data/Csv/Encoding.hs
@@ -26,6 +26,7 @@ module Data.Csv.Encoding
     , EncodeOptions(..)
     , defaultEncodeOptions
     , encodeWith
+    , encodeBuilderWith
     , encodeByNameWith
     ) where
 
@@ -174,10 +175,13 @@ defaultEncodeOptions = EncodeOptions
 -- | Like 'encode', but lets you customize how the CSV data is
 -- encoded.
 encodeWith :: ToRecord a => EncodeOptions -> [a] -> L.ByteString
-encodeWith opts
+encodeWith opts = toLazyByteString . encodeBuilderWith opts
+
+-- | Like 'encodeWith', but returns a 'Builder'.
+encodeBuilderWith :: ToRecord a => EncodeOptions -> [a] -> Builder
+encodeBuilderWith opts
     | validDelim (encDelimiter opts) =
-        toLazyByteString
-        . unlines (recordSep (encUseCrLf opts))
+          unlines (recordSep (encUseCrLf opts))
         . map (encodeRecord (encDelimiter opts) . toRecord)
     | otherwise = encodeOptionsError
 {-# INLINE encodeWith #-}


### PR DESCRIPTION
I wrote this patch to be as minimally invasive as possible. This allows
a streaming CSV encoder to be far more efficient, by allowing it to fill
up an existing buffer instead of creating a new buffer for each record.