### PR TITLE
Functions taking a custom record parser

### DIFF
--- a/Data/Csv.hs
+++ b/Data/Csv.hs
@@ -36,7 +36,9 @@ module Data.Csv
     , DecodeOptions(..)
     , defaultDecodeOptions
     , decodeWith
+    , decodeWith'
     , decodeByNameWith
+    , decodeByNameWith'
     , EncodeOptions(..)
     , defaultEncodeOptions
     , encodeWith


### PR DESCRIPTION
decodeWith' and decodeByNameWith' take a parser function instead of using the
one provided by the FromRecod / FromNamedRecord instances.

See issue #77 
