### PR TITLE
Fix #102 for foldl'

### DIFF
--- a/Data/Csv/Streaming.hs
+++ b/Data/Csv/Streaming.hs
@@ -115,6 +115,7 @@ foldlRecords' :: (a -> b -> a) -> a -> Records b -> a
 foldlRecords' f = go
   where
     go z (Cons (Right x) rs) = let z' = f z x in z' `seq` go z' rs
+    go z (Cons (Left _) rs) = go z rs
     go z _ = z
 {-# INLINE foldlRecords' #-}
 #endif

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -370,6 +370,7 @@ instanceTests =
   [
     testGroup "Records instances"
     [ testCase "foldr Foldable" (expected @=? F.foldr (:) [] input)
+    , testCase "foldl' Foldable" (expected @=? F.foldl' (flip (:)) [] input)
     ]
   ]
   where


### PR DESCRIPTION
This fixes a defect in the Foldable implementation for foldl'. The
documentation claims skipping over failed items, but stops the fold
instead.
