### PR TITLE
instance {From,To}Field Bool

### DIFF
--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -703,6 +703,17 @@ instance ToField Char where
     toField = toField . T.encodeUtf8 . T.singleton
     {-# INLINE toField #-}
 
+instance FromField Bool where
+    parseField "True"  = pure True
+    parseField "False" = pure False
+    parseField e       = typeError "Bool" e Nothing
+    {-# INLINE parseField #-}
+
+instance ToField Bool where
+    toField True  = "True"
+    toField False = "False"
+    {-# INLINE toField #-}
+
 -- | Accepts same syntax as 'rational'. Ignores whitespace.
 instance FromField Double where
     parseField = parseDouble

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -284,6 +284,7 @@ conversionTests :: [TF.Test]
 conversionTests =
     [ testGroup "roundTrip"
       [ testProperty "Char" (roundTrip :: Char -> Bool)
+      , testProperty "Bool" (roundTrip :: Bool -> Bool)
       , testProperty "ByteString" (roundTrip :: B.ByteString -> Bool)
       , testProperty "Int" (roundTrip :: Int -> Bool)
       , testProperty "Integer" (roundTrip :: Integer -> Bool)


### PR DESCRIPTION
I noticed that Bool doesn't have field instances, and propose to add these.

This PR contains all I need for now, but I'll ramble on a little about alternatives just in case.  Feel free to skip to the code and ignore the rest of this text.  (-:

I have also thought about making the FromField instance more lenient (accepting 'yes', '1', ...), but didn't like the assymetry and the expected performance penalty.  We could give the choice to the library user, though (not type-checked):

```haskell
import Data.CaseInsensitive

newtype LenientBool = LenientBool { fromLenientBool :: Bool }

instance FromField LenientBool where
    parseField s = pure $ mk s `elem` ["true", "yes", "on", "1"]

instance ToField LenientBool where
    toField (LenientBool True)  = "True"
    toField (LenientBool False) = "False"
```

Choices:
- do not depend on CaseInsensitive and just make the list longer?  (what about `trUE`?)
- make `LenientBool` less lenient and still reject `Essex St`.  (also reject `300`, or read it as `True`?  what about `300.2`?)
- write `true`, `false` in order to make the two types distinguishable in the output?

Such a small, simple problem, and so many things to consider!  :-)
