### PR TITLE
Update for GHC 8.0 Generics

### DIFF
--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -2,6 +2,8 @@
     BangPatterns,
     CPP,
     DefaultSignatures,
+    DataKinds,
+    PolyKinds,
     FlexibleContexts,
     FlexibleInstances,
     KindSignatures,
@@ -1018,7 +1020,7 @@ type Success a f r = a -> f r
 -- lets you compose several field conversions together in such a way
 -- that if any of them fail, the whole record conversion fails.
 newtype Parser a = Parser {
-      unParser :: forall f r.
+      unParser :: forall (f :: * -> *) (r :: *).
                   Failure f r
                -> Success a f r
                -> f r
@@ -1202,7 +1204,12 @@ instance GToNamedRecordHeader a => GToNamedRecordHeader (M1 C c a)
 
 -- | Instance to ensure that you cannot derive DefaultOrdered for
 -- constructors without selectors.
+#if MIN_VERSION_base(4,9,0)
+instance DefaultOrdered (M1 S ('MetaSel 'Nothing srcpk srcstr decstr) a ())
+         => GToNamedRecordHeader (M1 S ('MetaSel 'Nothing srcpk srcstr decstr) a)
+#else
 instance DefaultOrdered (M1 S NoSelector a ()) => GToNamedRecordHeader (M1 S NoSelector a)
+#endif
   where
     gtoNamedRecordHeader _ =
         error "You cannot derive DefaultOrdered for constructors without selectors."


### PR DESCRIPTION
There are two issues here,

 * `NoSelector` is now encoded as a `Maybe Symbol` field in `MetaSel`.

 * We now need `DataKinds` and `PolyKinds` to apply `Proxy` to a
   selector, of kind `Meta`.

Tested with GHC 7.8.4, 7.10.3, and 8.0-rc1.