### PR TITLE
Fix field error diagnostics being mapped to 'endOfInput' in Parser monad. Fixes #99

### DIFF
--- a/Data/Csv/Encoding.hs
+++ b/Data/Csv/Encoding.hs
@@ -357,18 +357,16 @@ decodeWithP p s =
 csv :: FromRecord a => DecodeOptions -> AL.Parser (V.Vector a)
 csv !opts = do
     vals <- records
-    _ <- optional endOfLine
-    endOfInput
     return $! V.fromList vals
   where
     records = do
         !r <- record (decDelimiter opts)
         if blankLine r
-            then (endOfLine *> records) <|> pure []
+            then (endOfInput *> pure []) <|> (endOfLine *> records)
             else case runParser (parseRecord r) of
                 Left msg  -> fail $ "conversion error: " ++ msg
                 Right val -> do
-                    !vals <- (endOfLine *> records) <|> AP.pure []
+                    !vals <- (endOfInput *> AP.pure []) <|> (endOfLine *> records)
                     return (val : vals)
 {-# INLINE csv #-}
 
@@ -378,19 +376,17 @@ csvWithHeader :: FromNamedRecord a => DecodeOptions
 csvWithHeader !opts = do
     !hdr <- header (decDelimiter opts)
     vals <- records hdr
-    _ <- optional endOfLine
-    endOfInput
     let !v = V.fromList vals
     return (hdr, v)
   where
     records hdr = do
         !r <- record (decDelimiter opts)
         if blankLine r
-            then (endOfLine *> records hdr) <|> pure []
+            then (endOfInput *> pure []) <|> (endOfLine *> records hdr)
             else case runParser (convert hdr r) of
                 Left msg  -> fail $ "conversion error: " ++ msg
                 Right val -> do
-                    !vals <- (endOfLine *> records hdr) <|> pure []
+                    !vals <- (endOfInput *> pure []) <|> (endOfLine *> records hdr)
                     return (val : vals)
 
     convert hdr = parseNamedRecord . Types.toNamedRecord hdr


### PR DESCRIPTION
This is my try to fix #99. Please see the commit message for an explanation.

It seems correct to me, but I would appreciate thorough review.

I also noticed that the test suite didn't raise an alarm when the only thing I did was to remove e.g. the `_ <- optional endOfLine`, so I'm not confident that the test suite actually captures exactly how this package should be have, and thus I'm not confident that the test suite would catch potential errors in this patch.
