### PR TITLE
Include benchmarks/*.csv with cabal sdist

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -16,7 +16,8 @@ Maintainer:          hvr@gnu.org
 Category:            Text, Web, CSV
 Build-type:          Simple
 Cabal-version:       >=1.10
-Extra-source-files:  examples/*.hs,
+Extra-source-files:  benchmarks/*.csv,
+                     examples/*.hs,
                      CHANGES.md
 Tested-with:         GHC ==8.0.1, GHC ==7.10.3, GHC ==7.8.4, GHC ==7.6.3
 


### PR DESCRIPTION
Currently, the benchmarks fail to run when obtained from Hackage:

```
Running 1 benchmarks...
Benchmark benchmarks: RUNNING...
benchmarks: benchmarks/presidents.csv: openBinaryFile: does not exist (No such file or directory)
Benchmark benchmarks: ERROR
```

since `cabal sdist` doesn't grab the `.csv` files in the `benchmarks` directory. Adding them to `extra-source-files` does the trick.

See also https://github.com/iu-parfunc/sc-haskell/issues/7