### PR TITLE
Restore GHC 7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-7.4.2"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.4.2], sources: [hvr-ghc]}}
     - compiler: "ghc-7.6.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3], sources: [hvr-ghc]}}

--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -2,8 +2,6 @@
     BangPatterns,
     CPP,
     DefaultSignatures,
-    DataKinds,
-    PolyKinds,
     FlexibleContexts,
     FlexibleInstances,
     KindSignatures,
@@ -14,6 +12,11 @@
     TypeOperators,
     UndecidableInstances
     #-}
+
+#if MIN_VERSION_base(4,9,0)
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+#endif
 
 module Data.Csv.Conversion
     (

--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -13,7 +13,7 @@
     UndecidableInstances
     #-}
 
-#if MIN_VERSION_base(4,9,0)
+#if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 #endif

--- a/cassava.cabal
+++ b/cassava.cabal
@@ -19,7 +19,7 @@ Cabal-version:       >=1.10
 Extra-source-files:  benchmarks/*.csv,
                      examples/*.hs,
                      CHANGES.md
-Tested-with:         GHC ==8.0.1, GHC ==7.10.3, GHC ==7.8.4, GHC ==7.6.3
+Tested-with:         GHC ==8.0.1, GHC ==7.10.3, GHC ==7.8.4, GHC ==7.6.3, GHC ==7.4.2
 
 Library
   default-language: Haskell2010
@@ -72,6 +72,7 @@ Library
     unordered-containers < 0.3,
     vector < 0.12
 
+  -- Prior to GHC 7.6, GHC.Generics lived in ghc-prim
   if impl(ghc >= 7.4 && < 7.6)
     build-depends: ghc-prim
 

--- a/cassava.cabal
+++ b/cassava.cabal
@@ -40,6 +40,11 @@ Library
     TypeOperators
     UndecidableInstances
 
+  if impl(ghc >= 8.0)
+    other-extensions:
+      DataKinds
+      PolyKinds
+
   Exposed-modules:
     Data.Csv
     Data.Csv.Builder
@@ -57,7 +62,7 @@ Library
   Build-depends:
     array < 0.6,
     attoparsec >= 0.10.2 && < 0.14,
-    base >= 4.6 && < 5,
+    base >= 4.5 && < 5,
     blaze-builder < 0.5,
     bytestring < 0.11,
     containers < 0.6,
@@ -66,6 +71,9 @@ Library
     text < 1.3,
     unordered-containers < 0.3,
     vector < 0.12
+
+  if impl(ghc >= 7.4 && < 7.6)
+    build-depends: ghc-prim
 
   ghc-options: -Wall -O2
 
@@ -76,7 +84,7 @@ Test-suite unit-tests
   Main-is: UnitTests.hs
   Build-depends:
     attoparsec,
-    base >= 4.6,
+    base >= 4.5,
     bytestring,
     cassava,
     hashable < 1.3,
@@ -112,7 +120,7 @@ Benchmark benchmarks
   Build-depends:
     array < 0.6,
     attoparsec >= 0.10.2 && < 0.14,
-    base >= 4.6 && < 5,
+    base >= 4.5 && < 5,
     blaze-builder < 0.5,
     bytestring < 0.11,
     containers < 0.6,
@@ -124,6 +132,9 @@ Benchmark benchmarks
     text,
     unordered-containers < 0.3,
     vector < 0.12
+
+  if impl(ghc >= 7.4 && < 7.6)
+    build-depends: ghc-prim
 
   ghc-options: -Wall -O2
 


### PR DESCRIPTION
Currently, installing `criterion` on GHC 7.4 is a bit inconvenient, since you have to install an old version of `cassava` to satisfy `criterion`'s dependencies. `cassava` already seems to build on GHC 7.4 with a few minor tweaks, so can we restore GHC 7.4 support?