### PR TITLE
Allow customising generic instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
  * Add `FromField`/`ToField` instance for `Natural` (#141,#142)
  * Add `FromField`/`ToField` instances for `Scientific` (#143,#144)
+ * Add support for modifying Generics-based instances (adding
+   `Options`, `defaultOptions`, `fieldLabelModifier`,
+   `genericParseRecord`, `genericToRecord`, `genericToNamedRecord`,
+   `genericHeaderOrder`) (#139,#140)
 
 ## Version 0.5.0.0
 

--- a/Data/Csv.hs
+++ b/Data/Csv.hs
@@ -93,6 +93,19 @@ module Data.Csv
     -- $fieldconversion
     , FromField(..)
     , ToField(..)
+
+    -- ** Generic record conversion
+    -- $genericconversion
+    , genericParseRecord
+    , genericToRecord
+    , genericParseNamedRecord
+    , genericToNamedRecord
+    , genericHeaderOrder
+
+    -- *** Generic type conversion options
+    , Options
+    , defaultOptions
+    , fieldLabelModifier
     ) where
 
 import Prelude hiding (lookup)
@@ -325,3 +338,29 @@ import Data.Csv.Types
 -- 'Field's and values you care about (e.g. 'Int's). Most of the time
 -- you don't need to write your own instances as the standard ones
 -- cover most use cases.
+
+-- $genericconversion
+--
+-- There may be times that you do not want to manually write out class
+-- instances for record conversion, but you can't rely upon the
+-- default instances (e.g. you can't create field names that match the
+-- actual column names in expected data).
+--
+-- For example, consider you have a type @MyType@ where you have
+-- prefixed certain columns with an underscore, but in the actual data
+-- they're not.  You can then write:
+--
+-- > myOptions :: Options
+-- > myOptions = defaultOptions { fieldLabelmodifier = rmUnderscore }
+-- >   where
+-- >     rmUnderscore ('_':str) = str
+-- >     rmUnderscore str       = str
+-- >
+-- > instance ToNamedRecord MyType where
+-- >   toNamedRecord = genericToNamedRecord myOptions
+-- >
+-- > instance FromNamedRecord MyType where
+-- >   parseNamedRecord = genericParseNamedRecord myOptions
+-- >
+-- > instance DefaultOrdered MyType where
+-- >   headerOrder = genericHeaderOrder myOptions

--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -137,6 +137,7 @@ fromStrict = L.fromChunks . (:[])
 --   datatype to\/from CSV.
 newtype Options = Options
   { fieldLabelModifier :: String -> String
+    -- ^ How to convert Haskell field labels to CSV fields.
   }
 
 -- | Default conversion options.

--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -133,6 +133,8 @@ fromStrict = L.fromChunks . (:[])
 ------------------------------------------------------------------------
 -- Index-based conversion
 
+-- | Options to customise how to generically encode\/decode your
+--   datatype to\/from CSV.
 newtype Options = Options
   { fieldLabelModifier :: String -> String
   }

--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -136,9 +136,13 @@ fromStrict = L.fromChunks . (:[])
 
 -- | Options to customise how to generically encode\/decode your
 --   datatype to\/from CSV.
+--
+--   @since 0.5.1.0
 newtype Options = Options
   { fieldLabelModifier :: String -> String
     -- ^ How to convert Haskell field labels to CSV fields.
+    --
+    --   @since 0.5.1.0
   }
 
 instance Show Options where
@@ -158,6 +162,8 @@ instance Show Options where
 --   { 'fieldLabelModifier' = id
 --   }
 --   @
+--
+--   @since 0.5.1.0
 defaultOptions :: Options
 defaultOptions = Options
   { fieldLabelModifier = id
@@ -194,6 +200,8 @@ class FromRecord a where
 -- | A configurable CSV record parser.  This function applied to
 --   'defaultOptions' is used as the default for 'parseRecord' when the
 --   type is an instance of 'Generic'.
+--
+--   @since 0.5.1.0
 genericParseRecord :: (Generic a, GFromRecord (Rep a)) => Options -> Record -> Parser a
 genericParseRecord opts r = to <$> gparseRecord opts r
 
@@ -221,6 +229,8 @@ class ToRecord a where
 -- | A configurable CSV record creator.  This function applied to
 --   'defaultOptions' is used as the default for 'toRecord' when the
 --   type is an instance of 'Generic'.
+--
+--   @since 0.5.1.0
 genericToRecord :: (Generic a, GToRecord (Rep a) Field) => Options -> a -> Record
 genericToRecord opts = V.fromList . gtoRecord opts . from
 
@@ -624,6 +634,8 @@ class FromNamedRecord a where
 -- | A configurable CSV named record parser.  This function applied to
 --   'defaultOptions' is used as the default for 'parseNamedRecord'
 --   when the type is an instance of 'Generic'.
+--
+--   @since 0.5.1.0
 genericParseNamedRecord :: (Generic a, GFromNamedRecord (Rep a)) => Options -> NamedRecord -> Parser a
 genericParseNamedRecord opts r = to <$> gparseNamedRecord opts r
 
@@ -648,6 +660,8 @@ class ToNamedRecord a where
 -- | A configurable CSV named record creator.  This function applied
 --   to 'defaultOptions' is used as the default for 'toNamedRecord' when
 --   the type is an instance of 'Generic'.
+--
+--   @since 0.5.1.0
 genericToNamedRecord :: (Generic a, GToRecord (Rep a) (B.ByteString, B.ByteString))
                         => Options -> a -> NamedRecord
 genericToNamedRecord opts = namedRecord . gtoRecord opts . from
@@ -691,6 +705,8 @@ class DefaultOrdered a where
 -- | A configurable CSV header record generator.  This function
 --   applied to 'defaultOptions' is used as the default for
 --   'headerOrder' when the type is an instance of 'Generic'.
+--
+--   @since 0.5.1.0
 genericHeaderOrder :: (Generic a, GToNamedRecordHeader (Rep a))
                       => Options -> a -> Header
 genericHeaderOrder opts = V.fromList. gtoNamedRecordHeader opts . from

--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -78,6 +78,7 @@ import qualified Data.ByteString.Lazy as L
 #if MIN_VERSION_bytestring(0,10,4)
 import qualified Data.ByteString.Short as SBS
 #endif
+import Data.List (intercalate)
 import Data.Hashable (Hashable)
 import qualified Data.HashMap.Lazy as HM
 import Data.Int (Int8, Int16, Int32, Int64)
@@ -139,6 +140,16 @@ newtype Options = Options
   { fieldLabelModifier :: String -> String
     -- ^ How to convert Haskell field labels to CSV fields.
   }
+
+instance Show Options where
+  show (Options fld) =
+    "Options {"
+      ++ intercalate ","
+         [ "fieldLabelModifier =~ " ++ show sampleField ++ " -> " ++ show (fld sampleField)
+         ]
+      ++ "}"
+    where
+      sampleField = "_column_A"
 
 -- | Default conversion options.
 --

--- a/cassava.cabal
+++ b/cassava.cabal
@@ -131,6 +131,10 @@ Test-suite unit-tests
 
   hs-source-dirs: tests
 
+  -- GHC.Generics lived in `ghc-prim` for GHC 7.2 & GHC 7.4 only
+  if impl(ghc < 7.6)
+    build-depends: ghc-prim == 0.2.*
+
   -- For Numeric.Natural
   if impl(ghc < 7.10)
     build-depends: nats >= 1 && < 1.2

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -1,5 +1,10 @@
-{-# LANGUAGE DeriveGeneric, OverloadedStrings, ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE CPP, DeriveGeneric, OverloadedStrings, ScopedTypeVariables #-}
+
+#if __GLASGOW_HASKELL__ >= 801
+{-# OPTIONS_GHC -Wno-orphans -Wno-unused-top-binds #-}
+#else
+{-# OPTIONS_GHC -fno-warn-orphans -fno-warn-unused-binds #-}
+#endif
 
 module Main
     ( main
@@ -27,6 +32,10 @@ import Test.Framework.Providers.QuickCheck2 as TF
 
 import Data.Csv hiding (record)
 import qualified Data.Csv.Streaming as S
+
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*>))
+#endif
 
 ------------------------------------------------------------------------
 -- Parse tests

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric, OverloadedStrings, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main
@@ -17,6 +17,7 @@ import qualified Data.Vector as V
 import qualified Data.Foldable as F
 import Data.Word
 import Numeric.Natural
+import GHC.Generics (Generic)
 import Test.HUnit
 import Test.Framework as TF
 import Test.Framework.Providers.HUnit as TF
@@ -382,6 +383,53 @@ instanceTests =
     expected = ["a" :: String]
 
 ------------------------------------------------------------------------
+-- Custom conversion option tests
+
+genericConversionTests :: [TF.Test]
+genericConversionTests =
+    [ testCase "headerOrder" (header ["column1", "column2", "column_3"] @=? hdrs)
+    , testCase "encode" (encodeDefaultOrderedByName sampleValues @?= sampleEncoding)
+    , testCase "decode" (Right (hdrs, V.fromList sampleValues) @=? decodeByName sampleEncoding)
+    , testProperty "roundTrip" rtProp
+    ]
+  where
+    hdrs = headerOrder (undefined :: SampleType)
+
+    sampleValues = [ SampleType ""      1     Nothing
+                   , SampleType "field" 99999 (Just 1.234)
+                   ]
+
+    sampleEncoding = "column1,column2,column_3\r\n,1,\r\nfield,99999,1.234\r\n"
+
+    rtProp :: [SampleType] -> Bool
+    rtProp vs = Right (hdrs, V.fromList vs)
+                == decodeByName (encodeDefaultOrderedByName vs)
+
+data SampleType = SampleType
+  { _column1  :: !T.Text
+  , column2   :: !Int
+  , _column_3 :: !(Maybe Double)
+  } deriving (Eq, Show, Read, Generic)
+
+sampleOptions :: Options
+sampleOptions = defaultOptions { fieldLabelModifier = rmUnderscore }
+  where
+    rmUnderscore ('_':str) = str
+    rmUnderscore str       = str
+
+instance ToNamedRecord SampleType where
+  toNamedRecord = genericToNamedRecord sampleOptions
+
+instance FromNamedRecord SampleType where
+  parseNamedRecord = genericParseNamedRecord sampleOptions
+
+instance DefaultOrdered SampleType where
+  headerOrder = genericHeaderOrder sampleOptions
+
+instance Arbitrary SampleType where
+  arbitrary = SampleType <$> arbitrary <*> arbitrary <*> arbitrary
+
+------------------------------------------------------------------------
 -- Test harness
 
 allTests :: [TF.Test]
@@ -390,6 +438,7 @@ allTests = [ testGroup "positional" positionalTests
            , testGroup "conversion" conversionTests
            , testGroup "custom-options" customOptionsTests
            , testGroup "instances" instanceTests
+           , testGroup "generic-conversions" genericConversionTests
            ]
 
 main :: IO ()


### PR DESCRIPTION
Only supports field name mangling (thus closes #139) at this time, but could add more options.