### PR TITLE
Use more compatible flag name

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -50,7 +50,7 @@ source-repository head
   type:     git
   location: https://github.com/hvr/cassava.git
 
-flag bytestring--LT-0_10_4
+flag bytestring-LT-0_10_4
   description: [bytestring](https://hackage.haskell.org/haskell/package/bytestring) < 0.10.4
 
 Library
@@ -105,7 +105,7 @@ Library
     vector >= 0.8 && < 0.13,
     Only >= 0.1 && < 0.1.1
 
-  if flag(bytestring--LT-0_10_4)
+  if flag(bytestring-LT-0_10_4)
     build-depends: bytestring <  0.10.4
                  , bytestring-builder >= 0.10.8 && < 0.11
   else


### PR DESCRIPTION
This flag name was changed without comment in 6e1ff781e062b4e01c7da347e7a3f74c60040c2c. It has caused a few problems:

- https://github.com/commercialhaskell/stack/issues/3345
- https://github.com/fpco/stackage/issues/2755
- https://github.com/fpco/stackage/issues/2759
- https://github.com/fpco/stackage/issues/2842
- https://github.com/haskell/cabal/issues/4686
- https://github.com/hvr/cassava/issues/150

Those problems either caused or accelerated some (attempted) changes in Cabal:

- https://github.com/haskell/cabal/pull/4654
- https://github.com/haskell/cabal/pull/4687
- https://github.com/haskell/cabal/pull/4696

Those problems also caused a change in Stack:

- https://github.com/commercialhaskell/stack/pull/3349

In short: Cabal never had any trouble with this. Stack did. The current master version of Stack can handle flags like this, but no released versions of it can. It's not clear when the next version of Stack will be released. In the meantime, no Stack users can use this package. This commit changes the offending flag to something that Stack can handle. By using a flag that Stack can handle, Stack users can once again use this package, and it can return to Stackage. There are no apparent downsides to using a more compatible flag name.